### PR TITLE
Reorganize project files by service and core functionalities

### DIFF
--- a/deezer/album.go
+++ b/deezer/album.go
@@ -1,0 +1,133 @@
+package deezer
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+// AlbumService defines a client to interface with the Deezer Album service
+type AlbumService struct {
+	client *Client
+}
+
+// Get fetches an Album given an album id.
+func (a *AlbumService) Get(id int) (*Album, *Response, error) {
+	i := strconv.Itoa(id)
+
+	url := fmt.Sprintf("album/%v", i)
+
+	req, err := a.client.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	album := new(Album)
+	resp, err := a.client.Do(req, album)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return album, resp, err
+
+}
+
+// Album represents an artist's album.
+type Album struct {
+	ID                    int            `json:"id"`
+	Title                 string         `json:"title"`
+	Upc                   string         `json:"upc"`
+	Link                  string         `json:"link"`
+	Share                 string         `json:"share"`
+	Cover                 string         `json:"cover"`
+	CoverSmall            string         `json:"cover_small"`
+	CoverMedium           string         `json:"cover_medium"`
+	CoverBig              string         `json:"cover_big"`
+	CoverXl               string         `json:"cover_xl"`
+	Md5Image              string         `json:"md5_image"`
+	GenreID               int            `json:"genre_id"`
+	Genres                Genres         `json:"genres"`
+	Label                 string         `json:"label"`
+	NbTracks              int            `json:"nb_tracks"`
+	Duration              int            `json:"duration"`
+	Fans                  int            `json:"fans"`
+	Rating                int            `json:"rating"`
+	ReleaseDate           string         `json:"release_date"`
+	RecordType            string         `json:"record_type"`
+	Available             bool           `json:"available"`
+	Tracklist             string         `json:"tracklist"`
+	ExplicitLyrics        bool           `json:"explicit_lyrics"`
+	ExplicitContentLyrics int            `json:"explicit_content_lyrics"`
+	ExplicitContentCover  int            `json:"explicit_content_cover"`
+	Contributors          []Contributors `json:"contributors"`
+	Artist                Artist         `json:"artist"`
+	Type                  string         `json:"type"`
+	Tracks                Tracks         `json:"tracks"`
+}
+
+// Genres is for Album
+type Genres struct {
+	Data []GenresData `json:"data"`
+}
+
+// GenresData is for Album
+type GenresData struct {
+	ID      int    `json:"id"`
+	Name    string `json:"name"`
+	Picture string `json:"picture"`
+	Type    string `json:"type"`
+}
+
+// Controbutors is for Album
+type Contributors struct {
+	ID            int    `json:"id"`
+	Name          string `json:"name"`
+	Link          string `json:"link"`
+	Share         string `json:"share"`
+	Picture       string `json:"picture"`
+	PictureSmall  string `json:"picture_small"`
+	PictureMedium string `json:"picture_medium"`
+	PictureBig    string `json:"picture_big"`
+	PictureXl     string `json:"picture_xl"`
+	Radio         bool   `json:"radio"`
+	Tracklist     string `json:"tracklist"`
+	Type          string `json:"type"`
+	Role          string `json:"role"`
+}
+
+// Artist is for Album
+type Artist struct {
+	ID            int    `json:"id"`
+	Name          string `json:"name"`
+	Picture       string `json:"picture"`
+	PictureSmall  string `json:"picture_small"`
+	PictureMedium string `json:"picture_medium"`
+	PictureBig    string `json:"picture_big"`
+	PictureXl     string `json:"picture_xl"`
+	Tracklist     string `json:"tracklist"`
+	Type          string `json:"type"`
+}
+
+// TracksData is for Album
+type TracksData struct {
+	ID                    int    `json:"id"`
+	Readable              bool   `json:"readable"`
+	Title                 string `json:"title"`
+	TitleShort            string `json:"title_short"`
+	TitleVersion          string `json:"title_version"`
+	Link                  string `json:"link"`
+	Duration              int    `json:"duration"`
+	Rank                  int    `json:"rank"`
+	ExplicitLyrics        bool   `json:"explicit_lyrics"`
+	ExplicitContentLyrics int    `json:"explicit_content_lyrics"`
+	ExplicitContentCover  int    `json:"explicit_content_cover"`
+	Preview               string `json:"preview"`
+	Md5Image              string `json:"md5_image"`
+	Artist                Artist `json:"artist"`
+	Type                  string `json:"type"`
+}
+
+// Tracks is for Album
+type Tracks struct {
+	Data []TracksData `json:"data"`
+}

--- a/deezer/album_test.go
+++ b/deezer/album_test.go
@@ -1,0 +1,33 @@
+package deezer
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestGetAlbum(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/album/", func(w http.ResponseWriter, r *http.Request) {
+		want := "GET"
+		got := r.Method
+		if got != want {
+			t.Errorf("Request method: %v, want %v", got, want)
+		}
+		fmt.Fprintf(w, `{"id": 44132881}`)
+	})
+
+	album, _, err := client.Albums.Get(44132881)
+	if err != nil {
+		t.Errorf("Album.Get return error: %v", err)
+	}
+
+	want := &Album{ID: 44132881}
+	if !reflect.DeepEqual(album, want) {
+		t.Errorf("Album.Get got: %#v, want %#v", album, want)
+	}
+
+}

--- a/deezer/deezer.go
+++ b/deezer/deezer.go
@@ -2,11 +2,9 @@ package deezer
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 )
 
 // Base URL for all the API methods
@@ -37,36 +35,10 @@ func NewClient() *Client {
 	return c
 }
 
-// AlbumService defines a client to interface with the Deezer Album service
-type AlbumService struct {
-	client *Client
-}
-
 // Response is a wrapper for the standard http.Response.
 // Typical use cases are: add pagination data, rate limits, etc.
 type Response struct {
 	*http.Response
-}
-
-// Get fetches an Album given an album id.
-func (a *AlbumService) Get(id int) (*Album, *Response, error) {
-	i := strconv.Itoa(id)
-
-	url := fmt.Sprintf("album/%v", i)
-
-	req, err := a.client.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	album := new(Album)
-	resp, err := a.client.Do(req, album)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return album, resp, err
-
 }
 
 // NewRequest creates a request. It takes care of using the BaseURL and setup common headers.
@@ -129,104 +101,4 @@ func newResponse(r *http.Response) *Response {
 	response := &Response{Response: r}
 	// TODO: Add pagination, response rate limits, etc.
 	return response
-}
-
-// Album represents an artist's album.
-type Album struct {
-	ID                    int            `json:"id"`
-	Title                 string         `json:"title"`
-	Upc                   string         `json:"upc"`
-	Link                  string         `json:"link"`
-	Share                 string         `json:"share"`
-	Cover                 string         `json:"cover"`
-	CoverSmall            string         `json:"cover_small"`
-	CoverMedium           string         `json:"cover_medium"`
-	CoverBig              string         `json:"cover_big"`
-	CoverXl               string         `json:"cover_xl"`
-	Md5Image              string         `json:"md5_image"`
-	GenreID               int            `json:"genre_id"`
-	Genres                Genres         `json:"genres"`
-	Label                 string         `json:"label"`
-	NbTracks              int            `json:"nb_tracks"`
-	Duration              int            `json:"duration"`
-	Fans                  int            `json:"fans"`
-	Rating                int            `json:"rating"`
-	ReleaseDate           string         `json:"release_date"`
-	RecordType            string         `json:"record_type"`
-	Available             bool           `json:"available"`
-	Tracklist             string         `json:"tracklist"`
-	ExplicitLyrics        bool           `json:"explicit_lyrics"`
-	ExplicitContentLyrics int            `json:"explicit_content_lyrics"`
-	ExplicitContentCover  int            `json:"explicit_content_cover"`
-	Contributors          []Contributors `json:"contributors"`
-	Artist                Artist         `json:"artist"`
-	Type                  string         `json:"type"`
-	Tracks                Tracks         `json:"tracks"`
-}
-
-// Genres is for Album
-type Genres struct {
-	Data []GenresData `json:"data"`
-}
-
-// GenresData is for Album
-type GenresData struct {
-	ID      int    `json:"id"`
-	Name    string `json:"name"`
-	Picture string `json:"picture"`
-	Type    string `json:"type"`
-}
-
-// Controbutors is for Album
-type Contributors struct {
-	ID            int    `json:"id"`
-	Name          string `json:"name"`
-	Link          string `json:"link"`
-	Share         string `json:"share"`
-	Picture       string `json:"picture"`
-	PictureSmall  string `json:"picture_small"`
-	PictureMedium string `json:"picture_medium"`
-	PictureBig    string `json:"picture_big"`
-	PictureXl     string `json:"picture_xl"`
-	Radio         bool   `json:"radio"`
-	Tracklist     string `json:"tracklist"`
-	Type          string `json:"type"`
-	Role          string `json:"role"`
-}
-
-// Artist is for Album
-type Artist struct {
-	ID            int    `json:"id"`
-	Name          string `json:"name"`
-	Picture       string `json:"picture"`
-	PictureSmall  string `json:"picture_small"`
-	PictureMedium string `json:"picture_medium"`
-	PictureBig    string `json:"picture_big"`
-	PictureXl     string `json:"picture_xl"`
-	Tracklist     string `json:"tracklist"`
-	Type          string `json:"type"`
-}
-
-// TracksData is for Album
-type TracksData struct {
-	ID                    int    `json:"id"`
-	Readable              bool   `json:"readable"`
-	Title                 string `json:"title"`
-	TitleShort            string `json:"title_short"`
-	TitleVersion          string `json:"title_version"`
-	Link                  string `json:"link"`
-	Duration              int    `json:"duration"`
-	Rank                  int    `json:"rank"`
-	ExplicitLyrics        bool   `json:"explicit_lyrics"`
-	ExplicitContentLyrics int    `json:"explicit_content_lyrics"`
-	ExplicitContentCover  int    `json:"explicit_content_cover"`
-	Preview               string `json:"preview"`
-	Md5Image              string `json:"md5_image"`
-	Artist                Artist `json:"artist"`
-	Type                  string `json:"type"`
-}
-
-// Tracks is for Album
-type Tracks struct {
-	Data []TracksData `json:"data"`
 }

--- a/deezer/deezer_test.go
+++ b/deezer/deezer_test.go
@@ -1,11 +1,9 @@
 package deezer
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"testing"
 )
 
@@ -59,29 +57,4 @@ func TestNewRequest_BadURL(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected error, got nil")
 	}
-}
-
-func TestGetAlbum(t *testing.T) {
-	client, mux, teardown := setup()
-	defer teardown()
-
-	mux.HandleFunc("/album/", func(w http.ResponseWriter, r *http.Request) {
-		want := "GET"
-		got := r.Method
-		if got != want {
-			t.Errorf("Request method: %v, want %v", got, want)
-		}
-		fmt.Fprintf(w, `{"id": 44132881}`)
-	})
-
-	album, _, err := client.Albums.Get(44132881)
-	if err != nil {
-		t.Errorf("Album.Get return error: %v", err)
-	}
-
-	want := &Album{ID: 44132881}
-	if !reflect.DeepEqual(album, want) {
-		t.Errorf("Album.Get got: %#v, want %#v", album, want)
-	}
-
 }


### PR DESCRIPTION
- Create a file (+tests) per service, e.g. album
- Keep core functionalities like client instantiation at base