### PR TITLE
Add test for malformed responses and a carrier for errors

### DIFF
--- a/deezer/codecov.yml
+++ b/deezer/codecov.yml
@@ -1,0 +1,24 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    patch:
+      default:
+        informational: true
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no

--- a/deezer/deezer_test.go
+++ b/deezer/deezer_test.go
@@ -141,3 +141,26 @@ func TestDo_withDeezerAPIError(t *testing.T) {
 	}
 
 }
+
+func TestDo_malformedResponse(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+		fmt.Fprintf(w, `{"key": "value"`)
+	})
+
+	type base struct {
+		Key string
+	}
+
+	req, _ := client.NewRequest(http.MethodGet, ".", nil)
+	body := new(base)
+	_, err := client.Do(req, body)
+
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+
+}


### PR DESCRIPTION
- Add test for malformed JSON responses
- Add a carrier field on the error response to conserve errors